### PR TITLE
Stop throwing unkown event type for valid events

### DIFF
--- a/web_socket.js
+++ b/web_socket.js
@@ -158,14 +158,14 @@
     if ("readyState" in event) {
       this.readyState = event.readyState;
     }
-    
+  
     try {
-      if (event.type == "open" && this.onopen) {
-        this.onopen();
-      } else if (event.type == "close" && this.onclose) {
-        this.onclose();
-      } else if (event.type == "error" && this.onerror) {
-        this.onerror(event);
+      if (event.type == "open") {
+        this.onopen && this.onopen();
+      } else if (event.type == "close") {
+        this.onclose && this.onclose();
+      } else if (event.type == "error") {
+        this.onerror && this.onerror(event);
       } else if (event.type == "message") {
         if (this.onmessage) {
           var data = decodeURIComponent(event.message);


### PR DESCRIPTION
The _handler throws unkown event errors if we do not attach a listener for the events. Listenen to the events should be optional not required.

This fix solves that issue. 
