### PR TITLE
Better Flash version detection

### DIFF
--- a/web_socket.js
+++ b/web_socket.js
@@ -12,7 +12,7 @@
     console = {log: function(){ }, error: function(){ }};
   }
   
-  if (!swfobject.hasFlashPlayerVersion("10.0.0")) {
+  if (!swfobject.getFlashPlayerVersion().major >= 10) {
     console.error("Flash Player >= 10.0.0 is required.");
     return;
   }


### PR DESCRIPTION
Hi,

My Linux box didn't get it's Flash version detected correctly; it's supposed to be 10.1 but I still got the error stating I'd need >=10.0. This change _does_ return the correct major version.
