### PR TITLE
Hooks and event sending

### DIFF
--- a/web_socket.js
+++ b/web_socket.js
@@ -319,6 +319,7 @@
           WebSocket.__instances[events[i].webSocketId].__handleEvent(events[i]);
         }
       } catch (e) {
+        eventCallback("flash-event-error", msg);
         console.error(e);
       }
     }, 0);
@@ -332,6 +333,7 @@
   
   // Called by Flash.
   WebSocket.__error = function(message) {
+    eventCallback("flash-error", decodeURIComponent(message));
     console.error(decodeURIComponent(message));
   };
   


### PR DESCRIPTION
Added a way to force the use of Flash over native WS (useful when debugging)

A simple event mechanism has also been added to aid developers using the web-socket-js library.
It allows to respond to certain events, such as SWF embed failure. Previously it just logged these with the console object (as you may know). I thought this was a better way of hooking in to what web-socket-js is up to.
Enables developers to show better error messages for their end users.

There's also possible to override the logging.
