### PR TITLE
init/close fix.

### DIFF
--- a/web_socket.js
+++ b/web_socket.js
@@ -51,8 +51,9 @@
     }
     // Uses setTimeout() to make sure __createFlash() runs after the caller sets ws.onopen etc.
     // Otherwise, when onopen fires immediately, onopen is called before it is set.
-    setTimeout(function() {
+    self.__createTask = setTimeout(function() {
       WebSocket.__addTask(function() {
+        self.__createTask = null;
         WebSocket.__flash.create(
             self.__id, url, protocols, proxyHost || null, proxyPort || 0, headers || null);
       });
@@ -89,6 +90,12 @@
    * Close this web socket gracefully.
    */
   WebSocket.prototype.close = function() {
+    if (this.__createTask) {
+        clearTimeout(this.__createTask);
+        this.__createTask = null;
+        this.readyState = WebSocket.CLOSED;
+        return;
+    }
     if (this.readyState == WebSocket.CLOSED || this.readyState == WebSocket.CLOSING) {
       return;
     }


### PR DESCRIPTION
This is change is prep the binary API support:

Change the init and close code so that the async __flash.create() task
is cancelled in close() so that you can do something like this which
tests whether the newer binary API exists:

```
var wstest = new WebSocket('ws://localhost:57111');
if (typeof(wstest.binaryType) !== "undefined") {
    ...
}
wstest.close();
wstest = null;
```

Without the change, a Flash error occurs later when the connect fails
(because the close() call doesn't cancel the connect).
