### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "gimite/web-socket-js",
-  "version": "1.0.1",
   "description": "HTML5 Web Socket implementation powered by Flash",
   "license": "New BSD",
   "ignore": [


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property