### PR TITLE
fix the empty cookie bug

### DIFF
--- a/flash-src/src/net/gimite/websocket/WebSocket.as
+++ b/flash-src/src/net/gimite/websocket/WebSocket.as
@@ -246,7 +246,7 @@ public class WebSocket extends EventDispatcher {
       "Sec-WebSocket-Key: {2}\r\n" +
       "Origin: {3}\r\n" +
       "Sec-WebSocket-Version: 13\r\n" +
-      "Cookie: {4}\r\n" +
+      (cookie == "" ? "" : "Cookie: {4}\r\n") +
       "{5}" +
       "\r\n",
       path, hostValue, key, origin, cookie, opt);


### PR DESCRIPTION
If the cookie is empty, i think it's not necessary to use the cookie header.
This can cause a bug when the websocket Server are using the QT API,the connenction can not be established.
I didn't check the rfc about the cookie , maybe some websocket server are compatible of empty cookie.